### PR TITLE
Update VueDawa.vue

### DIFF
--- a/src/components/VueDawa.vue
+++ b/src/components/VueDawa.vue
@@ -333,6 +333,13 @@ export default {
     },
     handleClickOutside (e) {
       const el = this.$refs.container
+      
+      //Handle scenario where VueDawa is inside a Bootstrap-Vue b-modal,
+      //which attempts to take focus before this event fires
+      if (e.type === 'focus' && e.relatedTarget && e.relatedTarget === this.$refs.input) {
+        return;
+      }
+      
       if (
         (e.target !== this.$refs.input &&
           e.target !== this.$refs.resultsList) ||


### PR DESCRIPTION
When VueDawa is inside a Bootstrap-Vue B-Modal, it's not possible to select a result, due to the modal taking focus before VueDawa's focus-event is called